### PR TITLE
[WIP] limit GitHub OAuth scope to avoid user concern

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -48,5 +48,5 @@ config :guardian_db, GuardianDb,
 config :ueberauth, Ueberauth,
   providers: [
     facebook: { Ueberauth.Strategy.Facebook, [profile_fields: "email,name"] },
-    github: { Ueberauth.Strategy.Github, [] }
+    github: { Ueberauth.Strategy.Github, [default_scope: "user:email,public_repo"] }
   ]


### PR DESCRIPTION
* 原來沒有設定 scope，會要求使用者的 profile 的完整權限，會造成部分使用者登入時的疑慮。[ref.](https://developer.github.com/v3/oauth/#scopes)

![](https://cloud.githubusercontent.com/assets/2316687/19508237/a80d3c58-960a-11e6-8779-901af72bddca.png)

* 限縮 GitHub 的存取權限到 `user:email` (for Gravatar) 與 `public_repo`。