### PR TITLE
Fix assets scss files are not be compile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 #RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 
 RUN apt-get update
-RUN apt-get install -y nodejs build-essential esl-erlang elixir
+RUN apt-get install -y nodejs build-essential esl-erlang elixir python
 
 # install the Phoenix Mix archive
 RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phoenix_new-$PHOENIX_VERSION.ez
@@ -39,10 +39,11 @@ RUN cd $(npm root -g)/npm \
   && npm install fs-extra \
   && sed -i -e s/graceful-fs/fs-extra/ -e s/fs\.rename/fs.move/ ./lib/utils/rename.js
 
+RUN sudo chown -R root /usr/local
+
 WORKDIR /app
 COPY . .
 
-RUN sudo chown -R root /usr/local
-RUN npm install --unsafe-perm
+RUN npm rebuild --unsafe-perm
 RUN ./node_modules/brunch/bin/brunch b -p \
   && MIX_ENV=prod mix do phoenix.digest, release --env=prod


### PR DESCRIPTION
在執行 `docker build -t elixir_tw .` 時發現以下錯誤訊息：

```
warn: Loading of sass-brunch failed due to Missing binding /app/node_modules/node-sass/vendor/linux-x64-48/binding.node
Node Sass could not find a binding for your current environment: Linux 64-bit with Node.js 6.x

Found bindings for the following environments:
  - OS X 64-bit with Unsupported runtime (51)

This usually happens because your environment has changed since running `npm install`.
Run `npm rebuild node-sass` to build the binding for your current environment.
```

所以我做了以下修改：

- 將 `npm install` 改成 `npm rebuild` 依照當前平台環境重新 build node modules

- 安裝 python 是因為 `fsevents` node module 在非 OSX 平台上使用 `npm rebuild` 的時候會需要用 `node-gyp` 編譯安裝，而 `node-gyp` 需要 Python

- 將 `RUN sudo chown -R root /usr/local` 移到 `COPY ..` 之前讓它被 Docker cache，不用每次 build Dockerfile 時都執行一次

這樣 build 出的 release 就能套用在 scss 檔案中自訂的 css style 了
