### PR TITLE
Wrap docker commands with backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ElixirTw
 
+[![Ebert](https://ebertapp.io/github/elixirtw/elixir_tw.svg)](https://ebertapp.io/github/elixirtw/elixir_tw)
+
 To start your Phoenix app:
 
   * Install dependencies with `mix deps.get`

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
 <!--Ready to run in production? Please [check our deployment guides](http://www.phoenixframework.org/docs/deployment).-->
 ## Building a release
-  * docker build -t elixir_tw .
-  * docker run -it -d elixir_tw:latest bash
-  * docker cp <IMAGE_ID>:/app/rel/elixir_tw/releases ./rel/docker_rel
-  * docker rm -f <IMAGE_ID>
+  * `docker build -t elixir_tw .`
+  * `docker run -it -d elixir_tw:latest bash`
+  * `docker cp <IMAGE_ID>:/app/rel/elixir_tw/releases ./rel/docker_rel`
+  * `docker rm -f <IMAGE_ID>`
 
 ## Learn more
 


### PR DESCRIPTION
`<IMAGE_ID>` is treated as HTML tag while parsing