### PR TITLE
Bugfix/guardian interface changed

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,13 +18,12 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
-config :guardian, Guardian,
+config :elixir_tw, ElixirTw.Auth.Guardian,
   # optional
-  allowed_algos: ["HS512"],
+  allowed_algos: ["ES512"],
   issuer: "ElixirTW",
   ttl: {30, :days},
-  verify_issuer: true,
-  serializer: ElixirTw.Account.GuardianSerializer
+  verify_issuer: true
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -40,7 +40,6 @@ config :phoenix, :stacktrace_depth, 20
 
 # Configure your database
 config :elixir_tw, ElixirTw.Repo,
-  adapter: Ecto.Adapters.Postgres,
   username: System.get_env("PGUSER") || "postgres",
   database: "elixir_tw_dev",
   hostname: "localhost",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -47,7 +47,7 @@ config :elixir_tw, ElixirTw.Repo,
   pool_size: 10
 
 # Configure Guardian
-config :guardian, Guardian,
+config :elixir_tw, ElixirTw.Auth.Guardian,
   allowed_algos: ["ES512"],
   secret_key: %{
     "crv" => "P-521",

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,7 +11,6 @@ config :logger, level: :warn
 
 # Configure your database
 config :elixir_tw, ElixirTw.Repo,
-  adapter: Ecto.Adapters.Postgres,
   username: System.get_env("PGUSER") || "postgres",
   database: "elixir_tw_test",
   hostname: "localhost",

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,7 +17,7 @@ config :elixir_tw, ElixirTw.Repo,
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
 
-config :guardian, Guardian,
+config :elixir_tw, ElixirTw.Auth.Guardian,
   issuer: "ElixirTW",
   ttl: {30, :days},
   verify_issuer: true,
@@ -30,7 +30,6 @@ config :guardian, Guardian,
       "AWXnRMCaj96pL33ZhTw5mW8vjcvYPRLbWLfIO21Aig5qBs7ymegVGZWAThWfZcBa13sgBXTBm6rv7RvKKTx8qZGW",
     "y" =>
       "AFWQhP0skj9iODTS4zn8vGcAAouvJ5HkLoBl72TNlh9WM6p0Cpc4Cf1XwRYkMzi-vVLpCEq27M22vZu__8FEV9io"
-  },
-  serializer: ElixirTwWeb.GuardianSerializer
+  }
 
 import_config "test*.secret.exs"

--- a/lib/elixir_tw/auth/guardian.ex
+++ b/lib/elixir_tw/auth/guardian.ex
@@ -1,17 +1,18 @@
-defmodule ElixirTw.Account.GuardianSerializer do
+defmodule ElixirTw.Auth.Guardian do
   @moduledoc nil
+  use Guardian, otp_app: :elixir_tw
 
   alias ElixirTw.Account
   alias Account.User
 
   def subject_for_token(%User{id: user_id}, _claims) do
-    {:ok, "User:" <> user_id}
+    {:ok, "User:#{user_id}"}
   end
 
   def subject_for_token(_, _), do: {:error, :unknown_resource}
 
   def resource_from_claims(%{"sub" => "User:" <> user_id}) do
-    case Account.get_user(user_id) do
+    case String.to_integer(user_id) |> Account.get_user() do
       %User{} = user -> {:ok, user}
       _ -> {:error, :resource_not_found}
     end

--- a/lib/elixir_tw/auth/user_error_handler.ex
+++ b/lib/elixir_tw/auth/user_error_handler.ex
@@ -1,0 +1,9 @@
+defmodule ElixirTw.Auth.UserErrorHandler do
+  use ElixirTwWeb, :controller
+
+  def auth_error(conn, {_type, reason}, _opts) do
+    conn
+    |> put_flash(:error, reason)
+    |> redirect(to: "/")
+  end
+end

--- a/lib/elixir_tw/auth/user_pipeline.ex
+++ b/lib/elixir_tw/auth/user_pipeline.ex
@@ -4,6 +4,6 @@ defmodule ElixirTw.Auth.UserPipeline do
     error_handler: ElixirTw.Auth.UserErrorHandler,
     module: ElixirTw.Auth.Guardian
 
-  plug Guardian.Plug.VerifySession, key: :user
+  plug Guardian.Plug.VerifySession
   plug Guardian.Plug.LoadResource, allow_blank: true
 end

--- a/lib/elixir_tw/repo.ex
+++ b/lib/elixir_tw/repo.ex
@@ -1,3 +1,5 @@
 defmodule ElixirTw.Repo do
-  use Ecto.Repo, otp_app: :elixir_tw
+  use Ecto.Repo,
+    otp_app: :elixir_tw,
+    adapter: Ecto.Adapters.Postgres
 end

--- a/lib/elixir_tw_web.ex
+++ b/lib/elixir_tw_web.ex
@@ -45,6 +45,7 @@ defmodule ElixirTwWeb do
   def controller do
     quote do
       use Phoenix.Controller, namespace: ElixirTwWeb
+      require Logger
 
       alias ElixirTw.Repo
       import Ecto
@@ -53,7 +54,7 @@ defmodule ElixirTwWeb do
       import ElixirTwWeb.Router.Helpers
       import ElixirTwWeb.Gettext
 
-      import Guardian.Plug, only: [current_resource: 1]
+      import ElixirTw.Auth.Guardian.Plug, only: [current_resource: 1]
 
       ElixirTwWeb.aliases()
     end

--- a/lib/elixir_tw_web.ex
+++ b/lib/elixir_tw_web.ex
@@ -51,7 +51,7 @@ defmodule ElixirTwWeb do
       import Ecto
       import Ecto.Query, only: [from: 1, from: 2]
 
-      import ElixirTwWeb.Router.Helpers
+      alias ElixirTwWeb.Router.Helpers, as: Routes
       import ElixirTwWeb.Gettext
 
       import ElixirTw.Auth.Guardian.Plug, only: [current_resource: 1]
@@ -71,10 +71,10 @@ defmodule ElixirTwWeb do
       # Use all HTML functionality (forms, tags, etc)
       use Phoenix.HTML
 
-      import ElixirTwWeb.Router.Helpers
+      alias ElixirTwWeb.Router.Helpers, as: Routes
       import ElixirTwWeb.ErrorHelpers
       import ElixirTwWeb.Gettext
-      import Guardian.Plug, only: [current_resource: 1]
+      import ElixirTw.Auth.Guardian.Plug, only: [current_resource: 1]
 
       ElixirTwWeb.aliases()
     end

--- a/lib/elixir_tw_web/channels/user_socket.ex
+++ b/lib/elixir_tw_web/channels/user_socket.ex
@@ -2,11 +2,7 @@ defmodule ElixirTwWeb.UserSocket do
   use Phoenix.Socket
 
   ## Channels
-  # channel "rooms:*", ElixirTw.RoomChannel
-
-  ## Transports
-  transport(:websocket, Phoenix.Transports.WebSocket)
-  # transport :longpoll, Phoenix.Transports.LongPoll
+  # channel "room:*", SampleWeb.RoomChannel
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After
@@ -19,18 +15,18 @@ defmodule ElixirTwWeb.UserSocket do
   #
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
-  def connect(_params, socket) do
+  def connect(_params, socket, _connect_info) do
     {:ok, socket}
   end
 
   # Socket id's are topics that allow you to identify all sockets for a given user:
   #
-  #     def id(socket), do: "users_socket:#{socket.assigns.user_id}"
+  #     def id(socket), do: "user_socket:#{socket.assigns.user_id}"
   #
   # Would allow you to broadcast a "disconnect" event and terminate
   # all active sockets and channels for a given user:
   #
-  #     ElixirTw.Endpoint.broadcast("users_socket:#{user.id}", "disconnect", %{})
+  #     SampleWeb.Endpoint.broadcast("user_socket:#{user.id}", "disconnect", %{})
   #
   # Returning `nil` makes this socket anonymous.
   def id(_socket), do: nil

--- a/lib/elixir_tw_web/channels/user_socket.ex
+++ b/lib/elixir_tw_web/channels/user_socket.ex
@@ -2,7 +2,7 @@ defmodule ElixirTwWeb.UserSocket do
   use Phoenix.Socket
 
   ## Channels
-  # channel "room:*", SampleWeb.RoomChannel
+  # channel "room:*", ElixirTwWeb.RoomChannel
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After
@@ -26,7 +26,7 @@ defmodule ElixirTwWeb.UserSocket do
   # Would allow you to broadcast a "disconnect" event and terminate
   # all active sockets and channels for a given user:
   #
-  #     SampleWeb.Endpoint.broadcast("user_socket:#{user.id}", "disconnect", %{})
+  #     ElixirTwWeb.Endpoint.broadcast("user_socket:#{user.id}", "disconnect", %{})
   #
   # Returning `nil` makes this socket anonymous.
   def id(_socket), do: nil

--- a/lib/elixir_tw_web/controllers/session_controller.ex
+++ b/lib/elixir_tw_web/controllers/session_controller.ex
@@ -4,7 +4,7 @@ defmodule ElixirTwWeb.SessionController do
   plug Ueberauth
   plug :scrub_params, "user" when action in [:create]
 
-  alias ElixirTw.Account
+  alias ElixirTw.{Account, Auth}
 
   def new(conn, params) do
     origin_url = Map.get(params, "origin_url", "/")
@@ -19,7 +19,7 @@ defmodule ElixirTwWeb.SessionController do
   end
 
   def delete(conn, _params) do
-    Guardian.Plug.sign_out(conn)
+    Auth.Guardian.Plug.sign_out(conn)
     |> put_flash(:info, "Logged out successfully")
     |> redirect(to: "/")
   end
@@ -37,12 +37,13 @@ defmodule ElixirTwWeb.SessionController do
   end
 
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
-    IO.inspect(auth, label: "auth")
+    Logger.info("ueberauth callback auth: #{inspect(auth)}")
 
     with user <- Account.get_user(auth.provider, auth.uid),
          {:ok, user} <- Account.create_user_with_oauth(user, auth) do
       conn
-      |> Guardian.Plug.sign_in(user)
+      |> Auth.Guardian.Plug.sign_in(user)
+      # TODO: When sign in failed, it will be redirected in UserErrorHandler before return. The following pipeline should be stopped.
       |> put_flash(:info, "驗證成功！")
       |> put_session(:current_user, user)
       |> redirect(to: get_session(conn, :origin_url))

--- a/lib/elixir_tw_web/controllers/user/post_controller.ex
+++ b/lib/elixir_tw_web/controllers/user/post_controller.ex
@@ -13,7 +13,7 @@ defmodule ElixirTwWeb.User.PostController do
       {:ok, post} ->
         conn
         |> put_flash(:info, "文章成功建立")
-        |> redirect(to: post_path(conn, :show, post.slug))
+        |> redirect(to: Routes.post_path(conn, :show, post.slug))
 
       {:error, changeset} ->
         conn
@@ -27,7 +27,7 @@ defmodule ElixirTwWeb.User.PostController do
       nil ->
         conn
         |> put_flash(:error, "不能修改文章")
-        |> redirect(to: post_path(conn, :show, slug))
+        |> redirect(to: Routes.post_path(conn, :show, slug))
 
       post ->
         changeset = Board.post_changeset(post)
@@ -40,7 +40,7 @@ defmodule ElixirTwWeb.User.PostController do
       {:ok, post} ->
         conn
         |> put_flash(:info, "文章成功更新")
-        |> redirect(to: post_path(conn, :show, post.slug))
+        |> redirect(to: Routes.post_path(conn, :show, post.slug))
 
       {:error, changeset} ->
         conn

--- a/lib/elixir_tw_web/endpoint.ex
+++ b/lib/elixir_tw_web/endpoint.ex
@@ -1,7 +1,9 @@
 defmodule ElixirTwWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :elixir_tw
 
-  socket "/socket", ElixirTwWeb.UserSocket
+  socket "/socket", ElixirTwWeb.UserSocket,
+    websocket: true,
+    longpoll: false
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/lib/elixir_tw_web/templates/layout/_user_sidebar.html.eex
+++ b/lib/elixir_tw_web/templates/layout/_user_sidebar.html.eex
@@ -3,7 +3,7 @@
     控制板
   </div>
   <div class="ui attached segment">
-    <%= link "新增文章", to: user_post_path(@conn, :new) %>
+    <%= link "新增文章", to: Routes.user_post_path(@conn, :new) %>
   </div>
   <div class="ui attached segment">
     <a href="/user">個人首頁</a>

--- a/lib/elixir_tw_web/templates/layout/app.html.eex
+++ b/lib/elixir_tw_web/templates/layout/app.html.eex
@@ -2,7 +2,7 @@
 <html lang="zh-tw">
   <head>
     <%= render "_head.html", conn: @conn %>
-    <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
+    <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>">
   </head>
 
   <body class="site">
@@ -63,5 +63,6 @@
         </div>
       </div>
     </footer>
+    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>

--- a/test/elixir_tw/account/account_test.exs
+++ b/test/elixir_tw/account/account_test.exs
@@ -48,7 +48,7 @@ defmodule ElixirTw.AccountTest do
         },
         provider: :facebook,
         strategy: Ueberauth.Strategy.Facebook,
-        uid: "10157894562480206"
+        uid: 10_157_894_562_480_206
       }
 
       %{oauth_stub: auth_stub}

--- a/test/elixir_tw_web/controllers/session_controller_test.exs
+++ b/test/elixir_tw_web/controllers/session_controller_test.exs
@@ -1,0 +1,34 @@
+defmodule ElixirTwWeb.SessionControllerTest do
+  use ElixirTwWeb.ConnCase
+  alias ElixirTw.Account.User
+  alias ElixirTwWeb.SessionController
+
+  @ueberauth_auth %{
+    credentials: %{token: "fdsnoafhnoofh08h38h"},
+    info: %{email: "bob@example.com", name: "Bob"},
+    provider: :github,
+    uid: 12_345_678
+  }
+
+  # Reference to https://github.com/ueberauth/ueberauth_example/issues/22
+  test "creates user from github information", %{conn: conn} do
+    conn =
+      conn
+      |> bypass_through(ElixirTwWeb.Router, [:browser])
+      |> assign(:ueberauth_auth, @ueberauth_auth)
+      |> get("/auth/github/callback")
+      |> put_session(:origin_url, "/")
+      |> SessionController.callback(%{})
+
+    users = Repo.all(User)
+    assert Enum.count(users) == 1
+    assert get_flash(conn, :info) == "驗證成功！"
+  end
+
+  test "DELETE /logout", %{conn: conn} do
+    conn = delete(conn, "/logout")
+
+    assert redirected_to(conn, 302) == "/"
+    assert get_flash(conn, :info) == "Logged out successfully"
+  end
+end


### PR DESCRIPTION
1. Fix Guardian login, the `uid` returned from GitHub OAuth changed from string to integer, not sure if it is consistent with Facebook OAuth. 
2. Fix logout button by putting the `app.js` back to the layout page. 
3. Fix the compiler warning